### PR TITLE
Remove Timeout.timeout from reline_compat.rb

### DIFF
--- a/src/ruby/reline_compat.rb
+++ b/src/ruby/reline_compat.rb
@@ -6,12 +6,3 @@ module Reline
     end
   end
 end
-
-module Timeout
-  def self.timeout(sec, klass = nil, message = nil, &block)
-    # possible problem
-    # See Reline using `Timeout.timeout` twice
-    yield
-  end
-end
-


### PR DESCRIPTION
`Timeout.timeout` is removed from Reline since v0.3.8.

https://github.com/ruby/reline/pull/580